### PR TITLE
Windows compatibility for pomostat

### DIFF
--- a/pomostat
+++ b/pomostat
@@ -12,12 +12,11 @@ import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt
 
-
-filename = os.path.join(os.getenv("HOME"), ".pomodoro")
+DATA_FILENAME = os.path.expanduser("~/.pomodoro")
 
 
 def load():
-    data = pd.read_csv(filename, parse_dates=["start"])
+    data = pd.read_csv(DATA_FILENAME, parse_dates=["start"])
     data = (data.loc[data["work"] == "work"])
     data["day"] = data["start"]
     data["day"] = data["day"].apply(lambda x: x.date())


### PR DESCRIPTION
Replace HOME env variable by os.path.expanduser for windows compatibility in pomostat.
Thanks to @charlesmst for the trick.